### PR TITLE
Rancher image version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ First you are likely to want to install a new rancher server. This is as
 simple as:
 
 ```puppet
-class { 'rancher:server': }
+class { 'rancher::server': }
 ```
 
 It is also possible to specify a custom port for the server to run on:
 
 ```puppet
-class { 'rancher:server':
+class { 'rancher::server':
   port => 9090,
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,17 +23,19 @@ class rancher (
   $registration_url,
   $agent_address = $::rancher::params::agent_address,
   $docker_socket = $::rancher::params::docker_socket,
+  $image_tag = $::rancher::params::image_tag,
 ) inherits ::rancher::params {
 
   validate_absolute_path($docker_socket)
   validate_string($registration_url)
+  validate_string($image_tag)
   validate_ip_address($agent_address)
 
   docker::image { 'rancher/agent': } ->
   exec { 'bootstrap rancher agent':
     path      => ['/usr/local/bin', '/usr/bin', '/bin'],
     logoutput => true,
-    command   => "docker run --privileged -v ${docker_socket}:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher -e 'CATTLE_AGENT_IP=${agent_address}' rancher/agent ${registration_url}",
+    command   => "docker run --privileged -v ${docker_socket}:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher -e 'CATTLE_AGENT_IP=${agent_address}' rancher/agent:${image_tag} ${registration_url}",
     unless    => 'docker inspect rancher-agent',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,4 +7,5 @@ class rancher::params {
   $server_port = 8080
   $docker_socket = '/var/run/docker.sock'
   $agent_address = $::ipaddress
+  $image_tag = 'latest'
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,12 +16,15 @@
 class rancher::server(
   $ensure = 'present',
   $port = $::rancher::params::server_port,
+  $image_tag = $::rancher::params::image_tag,
 ) inherits ::rancher::params {
 
   validate_re($ensure, '^(present|absent)', 'ensure should be present or absent')
   validate_integer($port)
 
-  docker::image { 'rancher/server': } ->
+  docker::image { 'rancher/server':
+    image_tag => $image_tag,
+  } ->
   docker::run { 'rancher-server':
     ensure => $ensure,
     image  => 'rancher/server',

--- a/spec/classes/rancher_server_spec.rb
+++ b/spec/classes/rancher_server_spec.rb
@@ -13,6 +13,7 @@ describe 'rancher::server' do
             is_expected.to compile.with_all_deps
             is_expected.to contain_class('rancher::params')
             is_expected.to contain_docker__image('rancher/server')
+              .with_image_tag('latest')
             is_expected.to contain_docker__run('rancher-server')
               .with_ensure('present')
               .with_image('rancher/server')
@@ -35,6 +36,15 @@ describe 'rancher::server' do
             is_expected.to compile.with_all_deps
             is_expected.to contain_docker__run('rancher-server')
               .with_ensure('absent')
+          end
+        end
+
+        context "with a custom image tag" do
+          let(:params) { { image_tag: 'v1.0.1' } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__image('rancher/server')
+              .with_image_tag('v1.0.1')
           end
         end
 

--- a/spec/classes/rancher_spec.rb
+++ b/spec/classes/rancher_spec.rb
@@ -49,6 +49,20 @@ describe 'rancher' do
           end
         end
 
+        context "with a custom image tag" do
+          let(:params) do
+            {
+              registration_url: 'http://127.0.0.1:8080/v1/scripts/DB121CFBA836F9493653:1434085200000:2ZOwUMd6fIzz44efikGhBP1veo',
+              image_tag: 'v1.0.1'
+            }
+          end
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_exec('bootstrap rancher agent')
+              .with_command(/rancher\/agent:v1.0.1/)
+          end
+        end
+
         context "with an invalid socket value" do
           let(:params) do
             {


### PR DESCRIPTION
db4d59c:
This commit adds the missing semicolons that should be present in the class declaration for a rancher server.

711f95f:
This commit adds a parameter for specifying the image tag/version for the rancher/server and rancher/agent Docker images.