### PR TITLE
Implemented additional rancher::server parameters and accompanying tests

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,4 +8,12 @@ class rancher::params {
   $docker_socket = '/var/run/docker.sock'
   $agent_address = $::ipaddress
   $image_tag = 'latest'
+  $container_name = 'rancher-server'
+  $db_port = 3306
+  $db_name = 'rancher'
+  $db_user = 'rancher'
+  $db_password = undef
+  $db_container = 'rancher-db'
+  $dns = []
+  $dns_search = []
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,21 +13,92 @@
 # * `port`
 #   The port to bind the Rancher server to. Defaults to 8080.
 #
+# * `image_tag`
+#   Docker image tag to use for the Rancher server image. Defauts to latest
+#
+# * `container_name`
+#   Name of the new Rancher container. Defaults to rancher-server
+#
+# * `db_port`
+#   Database port for using an external database container. Defaults to 3306    
+#
+# * `db_name`
+#   Name of the database. Defaults to rancher
+#
+# * `db_user`
+#   Database user. Defaults to rancher
+#
+# * `db_password`
+#   Password for the database user. Defaults to undef
+#
+# * `db_container`
+#   Name of the database container. Defaults to rancher-db
+#
+# * `dns`
+#   DNS server addresses to pass to the Rancher container. Defaults to the
+#   standard Docker-generated array.
+#
+# * `dns_search`
+#   DNS search domains to pass to the Rancher container. Defaults to the
+#   standard Docker-generated array.
+#
+
 class rancher::server(
   $ensure = 'present',
   $port = $::rancher::params::server_port,
   $image_tag = $::rancher::params::image_tag,
+  $container_name = $::rancher::params::container_name,
+  $db_port = $::rancher::params::db_port,
+  $db_name = $::rancher::params::db_name,
+  $db_user = $::rancher::params::db_user,
+  $db_password = $::rancher::params::db_password,
+  $db_container = $::rancher::params::db_container,
+  $dns = $::rancher::params::dns,
+  $dns_search = $::rancher::params::dns_search,
 ) inherits ::rancher::params {
 
   validate_re($ensure, '^(present|absent)', 'ensure should be present or absent')
   validate_integer($port)
+  validate_string($container_name)
+  validate_array($dns)
+  validate_array($dns_search)
+  
+  if  ($db_port != undef) and
+      ($db_name != undef) and
+      ($db_user != undef) and
+      ($db_password != undef) and
+      ($db_container != undef) {
+    validate_string($db_container)
+    validate_string($db_host)
+    validate_string($db_user)
+    validate_string($db_password)
+    validate_integer($db_port)
+    $env = [
+      "CATTLE_DB_CATTLE_MYSQL_HOST=${db_container}",
+      "CATTLE_DB_CATTLE_MYSQL_PORT=${db_port}",
+      "CATTLE_DB_CATTLE_MYSQL_NAME=${db_name}",
+      "CATTLE_DB_CATTLE_USERNAME=${db_user}",
+      "CATTLE_DB_CATTLE_PASSWORD=${db_password}",
+    ]
+    $links = [ $db_container ]
+    $depends = [ $db_container ]
+  } else {
+    $env = []
+    $links = []
+    $depends = []
+  }
 
   docker::image { 'rancher/server':
     image_tag => $image_tag,
   } ->
-  docker::run { 'rancher-server':
-    ensure => $ensure,
-    image  => 'rancher/server',
-    ports  => ["${port}:8080"],
+  docker::run { $container_name:
+    ensure     => $ensure,
+    image      => 'rancher/server',
+    ports      => ["${port}:8080"],
+    env        => $env,
+    links      => $links,
+    depends    => $depends,
+    dns        => $dns,
+    dns_search => $dns_search,
   }
 }

--- a/spec/classes/rancher_server_spec.rb
+++ b/spec/classes/rancher_server_spec.rb
@@ -75,6 +75,21 @@ describe 'rancher::server' do
           end
         end
 
+        context "create an external database" do
+          let(:params) { { db_password: 'test' } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__run('rancher-db')
+              .with_env([
+                'MYSQL_ROOT_PASSWORD=test',
+                'MYSQL_USER=rancher',
+                'MYSQL_PASSWORD=test',
+                'MYSQL_DATABASE=rancher',
+              ])
+              .with_volumes(['/var/lib/rancher-db:/var/lib/mysql'])
+              .with_image('mariadb')
+          end
+        end
         context "with an external database" do
           let(:params) { { db_password: 'test' } }
           it do
@@ -109,7 +124,6 @@ describe 'rancher::server' do
               .with_dns_search(['domain.local'])
           end
         end
-
       end
     end
   end

--- a/spec/classes/rancher_server_spec.rb
+++ b/spec/classes/rancher_server_spec.rb
@@ -18,6 +18,11 @@ describe 'rancher::server' do
               .with_ensure('present')
               .with_image('rancher/server')
               .with_ports(['8080:8080'])
+              .with_env([])
+              .with_depends([])
+              .with_links([])
+              .with_dns([])
+              .with_dns_search([])
           end
         end
 
@@ -61,6 +66,50 @@ describe 'rancher::server' do
             expect { is_expected.to contain_docker_run('rancher-server') }.to raise_error(Puppet::Error, /Expected first argument to be an Integer/)
           end
         end
+
+        context "with an custom container name" do
+          let(:params) { { container_name: 'rancher' } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__run('rancher')
+          end
+        end
+
+        context "with an external database" do
+          let(:params) { { db_password: 'test' } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__run('rancher-server')
+              .with_links(['rancher-db'])
+              .with_depends(['rancher-db'])
+              .with_env([
+                'CATTLE_DB_CATTLE_MYSQL_HOST=rancher-db',
+                'CATTLE_DB_CATTLE_MYSQL_PORT=3306',
+                'CATTLE_DB_CATTLE_MYSQL_NAME=rancher',
+                'CATTLE_DB_CATTLE_USERNAME=rancher',
+                'CATTLE_DB_CATTLE_PASSWORD=test',
+              ])
+          end
+        end
+
+        context "with a custom DNS server" do
+          let(:params) { { dns: ['8.8.8.8'] } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__run('rancher-server')
+              .with_dns(['8.8.8.8'])
+          end
+        end
+
+        context "with a custom DNS search domain" do
+          let(:params) { { dns_search: ['domain.local'] } }
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_docker__run('rancher-server')
+              .with_dns_search(['domain.local'])
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Hi Gareth,

I'm back with another pull request: I've added a few new parameters for rancher::server, along with rspec tests. The new parameters allow for the use of an external database container, along with the ability to specify custom DNS servers, DNS search domains, and Docker container name. Please let me know what you think and if there's anything you'd like me to add.

Cheers,
Isaac