### PR TITLE
Use image_tag for the server

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,7 +23,7 @@
 #   Name of the new Rancher container. Defaults to rancher-server
 #
 # * `db_port`
-#   Database port for using an external database container. Defaults to 3306    
+#   Database port for using an external database container. Defaults to 3306
 #
 # * `db_name`
 #   Name of the database. Defaults to rancher
@@ -65,7 +65,7 @@ class rancher::server(
   validate_string($container_name)
   validate_array($dns)
   validate_array($dns_search)
-  
+
   if  ($db_port != undef) and
       ($db_name != undef) and
       ($db_user != undef) and
@@ -110,7 +110,7 @@ class rancher::server(
   } ->
   docker::run { $container_name:
     ensure     => $ensure,
-    image      => 'rancher/server',
+    image      => 'rancher/server:${image_tag}',
     ports      => ["${port}:8080"],
     env        => $env,
     links      => $links,


### PR DESCRIPTION
If you specify an image_tag, it's pulled down but may not be used because this docker::run resource just specifies the rancher/server image, and that will pull and use 'latest' if not specified. Since this module sets image_tag to 'latest' anyways, there's no change in default behaviour. However, now if you set rancher::params::image_tag or rancher::server::image_tag, it will actually use it. Such as if you want to try out the 2.0 alpha for example.