### PR TITLE
Use puppetlabs-docker instead of broken garethr-docker

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   forge_modules:
     stdlib: 'puppetlabs-stdlib'
-    docker: 'garethr-docker'
+    docker: 'puppetlabs-docker'
   symlinks:
     rancher: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,8 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-rancher",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-rancher/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"garethr-docker","version_requirement":">= 5.0.0"}
+    {"name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0"},
+    {"name": "puppetlabs-docker", "version_requirement": ">= 1.0.2 < 2.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [


### PR DESCRIPTION
This module still depends on the [garethr-docker](https://forge.puppet.com/garethr/docker) Puppet module, which seems to have been abandoned and replaced by the fairly new [puppetlabs-docker](https://forge.puppet.com/puppetlabs/docker).

Without updating the dependency installing Rancher with this module fails.