### PR TITLE
[Issue-9] Adding --rm flag to rancher class 'docker run' command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class rancher (
   exec { 'bootstrap rancher agent':
     path      => ['/usr/local/bin', '/usr/bin', '/bin'],
     logoutput => true,
-    command   => "docker run --privileged -v ${docker_socket}:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher -e 'CATTLE_AGENT_IP=${agent_address}' rancher/agent:${image_tag} ${registration_url}",
+    command   => "docker run --rm --privileged -v ${docker_socket}:/var/run/docker.sock -v /var/lib/rancher:/var/lib/rancher -e 'CATTLE_AGENT_IP=${agent_address}' rancher/agent:${image_tag} ${registration_url}",
     unless    => 'docker inspect rancher-agent',
   }
 }


### PR DESCRIPTION
Fix for Issue #9 to clean up the rancher/agent initialization container once it completes its tasks and stops itself by adding the `--rm` flag to the `docker run` command in the rancher class's exec as per the suggested command given by the rancher server's UI when adding a new host